### PR TITLE
Support upload of nested directories

### DIFF
--- a/lib/remote-storage.js
+++ b/lib/remote-storage.js
@@ -16,6 +16,7 @@ const mime = require('mime-types')
 const utils = require('./utils')
 const fs = require('fs-extra')
 const joi = require('@hapi/joi')
+const klaw = require('klaw')
 
 module.exports = class RemoteStorage {
   /**
@@ -99,16 +100,24 @@ module.exports = class RemoteStorage {
    */
   async uploadDir (dir, prefix, postFileUploadCallback) {
     if (typeof prefix !== 'string') throw new Error('prefix must be a valid string')
-    async function _filterFiles (files) {
-      const bools = await Promise.all(files.map(async f => (await fs.stat(f)).isFile()))
-      return files.filter(f => bools.shift())
-    }
 
-    const files = await _filterFiles((await fs.readdir(dir)).map(f => path.join(dir, f)))
+    // walk the whole directory recursively using klaw.
+    const files = []
+    for await (const file of klaw(dir)) {
+      if (file.stats.isFile()) {
+        files.push(file.path)
+      }
+    }
 
     // parallel upload
     return Promise.all(files.map(async f => {
-      const s3Res = await this.uploadFile(f, prefix)
+      // get file's relative folder to the base directory.
+      var prefixDirectory = path.dirname(path.relative(dir, f))
+      // base directory returns ".", ignore that.
+      prefixDirectory = prefixDirectory === '.' ? '' : prefixDirectory
+      // newPrefix is now the initial prefix plus the files relative directory path.
+      const newPrefix = utils.urlJoin(prefix, prefixDirectory)
+      const s3Res = await this.uploadFile(f, newPrefix)
       if (postFileUploadCallback) postFileUploadCallback(f)
       return s3Res
     }))

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "execa": "^3.2.0",
     "fs-extra": "^8.1.0",
     "js-yaml": "^3.13.1",
+    "klaw": "^3.0.0",
     "lodash.clonedeep": "^4.5.0",
     "mime-types": "^2.1.24",
     "node-fetch": "^2.6.0",

--- a/scripts/deploy.ui.js
+++ b/scripts/deploy.ui.js
@@ -51,7 +51,7 @@ class DeployUI extends BaseScript {
       this.emit('warning', `an already existing deployment for version ${this.config.app.version} will be overwritten`)
       await remoteStorage.emptyFolder(this.config.s3.folder)
     }
-    await remoteStorage.uploadDir(dist, this.config.s3.folder, f => this.emit('progress', path.basename(f)))
+    await remoteStorage.uploadDir(dist, this.config.s3.folder, f => this.emit('progress', path.relative(dist, f)))
 
     const url = utils.getUIUrl(this.config, creds.params.Bucket)
     this.emit('end', taskName, url)

--- a/test/jest.setup.js
+++ b/test/jest.setup.js
@@ -103,7 +103,10 @@ global.addFakeFiles = (vol, dir, files) => {
   if (Array.isArray(files)) files = files.reduce((obj, curr) => { obj[curr] = 'fake-content'; return obj }, {})
   vol.mkdirpSync(dir)
   Object.keys(files).forEach(f => {
-    vol.writeFileSync(path.join(dir, f), files[f])
+    const filePath = path.join(dir, f)
+    // create intermediate directories if neccessary
+    vol.mkdirSync(path.dirname(filePath), { recursive: true })
+    vol.writeFileSync(filePath, files[f])
   })
 }
 

--- a/test/lib/remote-storage.test.js
+++ b/test/lib/remote-storage.test.js
@@ -153,7 +153,7 @@ test('uploadDir should call S3#upload one time per file', async () => {
 })
 
 test('uploadDir should call a callback once per uploaded file', async () => {
-  await global.addFakeFiles(vol, 'fakeDir', ['index.js', 'index.css', 'index.html'])
+  await global.addFakeFiles(vol, 'fakeDir', ['index.js', 'index.css', 'index.html', 'test/i.js'])
   const uploadMock = jest.fn()
   spyS3({
     upload: uploadMock
@@ -161,5 +161,5 @@ test('uploadDir should call a callback once per uploaded file', async () => {
   const cbMock = jest.fn()
   const rs = new RemoteStorage(global.fakeTVMResponse)
   await rs.uploadDir('fakeDir', 'fakeprefix', cbMock)
-  expect(cbMock).toHaveBeenCalledTimes(3)
+  expect(cbMock).toHaveBeenCalledTimes(4)
 })

--- a/test/scripts/deploy.ui.test.js
+++ b/test/scripts/deploy.ui.test.js
@@ -10,6 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 const { vol } = global.mockFs()
+const path = require('path')
 const cloneDeep = require('lodash.clonedeep')
 
 const RemoteStorage = require('../../lib/remote-storage')
@@ -144,7 +145,7 @@ describe('deploy static files with tvm', () => {
     await global.addFakeFiles(vol, buildDir, ['index.html'])
     // spies can be restored
     const spy = jest.spyOn(RemoteStorage.prototype, 'uploadDir').mockImplementation((dir, prefix, progressCb) => {
-      progressCb('index.html')
+      progressCb(path.join(buildDir, 'index.html'))
     })
     await scripts.deployUI()
     expect(mockOnProgress).toHaveBeenCalledWith('index.html')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add support for uploading nested directories to CDN.

This PR adds the  [Kalw](https://github.com/jprichardson/node-klaw) dependency (fairly lightweight) for recursively reading directories.

<!--- Describe your changes in detail -->

## Related Issue
Fixes: #69
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
see #69
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
