### PR TITLE
Cache metadata support

### DIFF
--- a/lib/config-loader.js
+++ b/lib/config-loader.js
@@ -21,6 +21,10 @@ const aioLogger = require('@adobe/aio-lib-core-logging')('@adobe/aio-app-scripts
 const defaultAioHostname = 'adobeio-static.net'
 const defaultTvmUrl = 'https://adobeio.adobeioruntime.net/apis/tvm/'
 const defaultOwApiHost = 'https://adobeioruntime.net'
+const defaultHTMLCacheDuration = '60'
+const defaultJSCacheDuration = '604800'
+const defaultCSSCacheDuration = '604800'
+const defaultImageCacheDuration = '604800'
 
 /** loading config returns following object (this config is internal, not user facing):
 {
@@ -139,6 +143,11 @@ module.exports = () => {
   config.s3.tvmUrl = userConfig.cna.tvmurl || defaultTvmUrl
   // only provide a hostname if it was given or if the app uses the tvm
   config.app.hostname = userConfig.cna.hostname || defaultAioHostname
+  //cache control config
+  config.app.htmlCacheDuration = userConfig.cna.htmlCacheDuration || defaultHTMLCacheDuration
+  config.app.jsCacheDuration = userConfig.cna.jsCacheDuration || defaultJSCacheDuration
+  config.app.cssCacheDuration = userConfig.cna.cssCacheDuration || defaultCSSCacheDuration
+  config.app.imagesCacheDuration = userConfig.cna.imagesCacheDuration || defaultImageCacheDuration
 
   return config
 }

--- a/lib/config-loader.js
+++ b/lib/config-loader.js
@@ -143,11 +143,11 @@ module.exports = () => {
   config.s3.tvmUrl = userConfig.cna.tvmurl || defaultTvmUrl
   // only provide a hostname if it was given or if the app uses the tvm
   config.app.hostname = userConfig.cna.hostname || defaultAioHostname
-  //cache control config
-  config.app.htmlCacheDuration = userConfig.cna.htmlCacheDuration || defaultHTMLCacheDuration
-  config.app.jsCacheDuration = userConfig.cna.jsCacheDuration || defaultJSCacheDuration
-  config.app.cssCacheDuration = userConfig.cna.cssCacheDuration || defaultCSSCacheDuration
-  config.app.imagesCacheDuration = userConfig.cna.imagesCacheDuration || defaultImageCacheDuration
+  // cache control config
+  config.app.htmlCacheDuration = userConfig.cna.htmlcacheduration || defaultHTMLCacheDuration
+  config.app.jsCacheDuration = userConfig.cna.jscacheduration || defaultJSCacheDuration
+  config.app.cssCacheDuration = userConfig.cna.csscacheduration || defaultCSSCacheDuration
+  config.app.imageCacheDuration = userConfig.cna.imagecacheduration || defaultImageCacheDuration
 
   return config
 }

--- a/lib/remote-storage.js
+++ b/lib/remote-storage.js
@@ -129,22 +129,21 @@ module.exports = class RemoteStorage {
     }))
   }
 
-    /**
+  /**
     * Get cache control string based on mime type and config
     * @param {string} mimeType - mime type
     * @param  {Object} appConfig - application config
     */
-  _getCacheControlConfig(mimeType, appConfig) {
-    let cacheControlStr = "s-maxage=0"
-    if(mimeType === mime.lookup("html"))
-      return cacheControlStr + ", max-age=" + appConfig.htmlCacheDuration
-    else if(mimeType === mime.lookup("js"))
-      return cacheControlStr + ", max-age=" + appConfig.jsCacheDuration
-    else if(mimeType === mime.lookup("css"))
-      return cacheControlStr + ", max-age=" + appConfig.cssCacheDuration
-    else if(mimeType.startsWith("image"))
-      return cacheControlStr + ", max-age=" + appConfig.imagesCacheDuration
-    else
-      return cacheControlStr
+  _getCacheControlConfig (mimeType, appConfig) {
+    const cacheControlStr = 's-maxage=0'
+    if (mimeType === mime.lookup('html')) {
+      return cacheControlStr + ', max-age=' + appConfig.htmlCacheDuration
+    } else if (mimeType === mime.lookup('js')) {
+      return cacheControlStr + ', max-age=' + appConfig.jsCacheDuration
+    } else if (mimeType === mime.lookup('css')) {
+      return cacheControlStr + ', max-age=' + appConfig.cssCacheDuration
+    } else if (mimeType.startsWith('image')) {
+      return cacheControlStr + ', max-age=' + appConfig.imageCacheDuration
+    } else { return cacheControlStr }
   }
 }

--- a/lib/remote-storage.js
+++ b/lib/remote-storage.js
@@ -89,7 +89,7 @@ module.exports = class RemoteStorage {
       Body: content,
       ACL: 'public-read',
       // s3 misses some mime types like for css files
-      ContentType: mime,
+      ContentType: mimeType,
       CacheControl: cacheControlString
     }
     return this.s3.upload(uploadParams).promise()

--- a/lib/remote-storage.js
+++ b/lib/remote-storage.js
@@ -77,16 +77,20 @@ module.exports = class RemoteStorage {
    * Uploads a file
    * @param  {string} file
    * @param  {string} prefix - prefix to upload the file to
+   * @param  {Object} appConfig - application config
    */
-  async uploadFile (file, prefix) {
+  async uploadFile (file, prefix, appConfig) {
     if (typeof prefix !== 'string') throw new Error('prefix must be a valid string')
     const content = await fs.readFile(file)
+    const mimeType = mime.lookup(path.extname(file))
+    const cacheControlString = this._getCacheControlConfig(mimeType, appConfig)
     const uploadParams = {
       Key: utils.urlJoin(prefix, path.basename(file)),
       Body: content,
       ACL: 'public-read',
       // s3 misses some mime types like for css files
-      ContentType: mime.lookup(path.extname(file))
+      ContentType: mime,
+      CacheControl: cacheControlString
     }
     return this.s3.upload(uploadParams).promise()
   }
@@ -95,9 +99,10 @@ module.exports = class RemoteStorage {
    * Uploads all files in a dir to - flat, no recursion support
    * @param  {string} dir - directory with files to upload
    * @param  {string} prefix - prefix to upload the dir to
+   * @param  {Object} appConfig - application config
    * @param  {function} [postFileUploadCallback] - called for each uploaded file
    */
-  async uploadDir (dir, prefix, postFileUploadCallback) {
+  async uploadDir (dir, prefix, appConfig, postFileUploadCallback) {
     if (typeof prefix !== 'string') throw new Error('prefix must be a valid string')
     async function _filterFiles (files) {
       const bools = await Promise.all(files.map(async f => (await fs.stat(f)).isFile()))
@@ -108,9 +113,28 @@ module.exports = class RemoteStorage {
 
     // parallel upload
     return Promise.all(files.map(async f => {
-      const s3Res = await this.uploadFile(f, prefix)
+      const s3Res = await this.uploadFile(f, prefix, appConfig)
       if (postFileUploadCallback) postFileUploadCallback(f)
       return s3Res
     }))
+  }
+
+    /**
+    * Get cache control string based on mime type and config
+    * @param {string} mimeType - mime type
+    * @param  {Object} appConfig - application config
+    */
+  _getCacheControlConfig(mimeType, appConfig) {
+    let cacheControlStr = "s-maxage=0"
+    if(mimeType === mime.lookup("html"))
+      return cacheControlStr + ", max-age=" + appConfig.htmlCacheDuration
+    else if(mimeType === mime.lookup("js"))
+      return cacheControlStr + ", max-age=" + appConfig.jsCacheDuration
+    else if(mimeType === mime.lookup("css"))
+      return cacheControlStr + ", max-age=" + appConfig.cssCacheDuration
+    else if(mimeType.startsWith("image"))
+      return cacheControlStr + ", max-age=" + appConfig.imagesCacheDuration
+    else
+      return cacheControlStr
   }
 }

--- a/scripts/deploy.ui.js
+++ b/scripts/deploy.ui.js
@@ -51,7 +51,7 @@ class DeployUI extends BaseScript {
       this.emit('warning', `an already existing deployment for version ${this.config.app.version} will be overwritten`)
       await remoteStorage.emptyFolder(this.config.s3.folder)
     }
-    await remoteStorage.uploadDir(dist, this.config.s3.folder, f => this.emit('progress', path.basename(f)))
+    await remoteStorage.uploadDir(dist, this.config.s3.folder, this.config.app, f => this.emit('progress', path.basename(f)))
 
     const url = utils.getUIUrl(this.config, creds.params.Bucket)
     this.emit('end', taskName, url)

--- a/test/jest.setup.js
+++ b/test/jest.setup.js
@@ -154,7 +154,7 @@ global.fakeConfig = {
     htmlCacheDuration: 60,
     jsCacheDuration: 604800,
     cssCacheDuration: 604800,
-    imagesCacheDuration: 604800
+    imageCacheDuration: 604800
   }
 }
 

--- a/test/jest.setup.js
+++ b/test/jest.setup.js
@@ -144,12 +144,14 @@ global.fakeConfig = {
     cna: {
       s3bucket: 'customBucket',
       awsaccesskeyid: 'fakeAwsKeyId',
-      awssecretaccesskey: 'fakeAwsSecretKey',
-      htmlCacheDuration: 60,
-      jsCacheDuration: 604800,
-      cssCacheDuration: 604800,
-      imagesCacheDuration: 604800
+      awssecretaccesskey: 'fakeAwsSecretKey'
     }
+  },
+  cna: {
+    htmlCacheDuration: 60,
+    jsCacheDuration: 604800,
+    cssCacheDuration: 604800,
+    imagesCacheDuration: 604800
   }
 }
 

--- a/test/jest.setup.js
+++ b/test/jest.setup.js
@@ -144,7 +144,11 @@ global.fakeConfig = {
     cna: {
       s3bucket: 'customBucket',
       awsaccesskeyid: 'fakeAwsKeyId',
-      awssecretaccesskey: 'fakeAwsSecretKey'
+      awssecretaccesskey: 'fakeAwsSecretKey',
+      htmlCacheDuration: 60,
+      jsCacheDuration: 604800,
+      cssCacheDuration: 604800,
+      imagesCacheDuration: 604800
     }
   }
 }

--- a/test/lib/remote-storage.test.js
+++ b/test/lib/remote-storage.test.js
@@ -136,7 +136,8 @@ test('uploadFile should call S3#upload with the correct parameters', async () =>
     upload: uploadMock
   })
   const rs = new RemoteStorage(global.fakeTVMResponse)
-  await rs.uploadFile('fakeDir/index.js', 'fakeprefix')
+  const fakeConfig = {}
+  await rs.uploadFile('fakeDir/index.js', 'fakeprefix', fakeConfig)
   const body = Buffer.from('fake content', 'utf8')
   expect(uploadMock).toHaveBeenCalledWith(expect.objectContaining({ Key: 'fakeprefix/index.js', Body: body }))
 })
@@ -148,7 +149,7 @@ test('uploadDir should call S3#upload one time per file', async () => {
     upload: uploadMock
   })
   const rs = new RemoteStorage(global.fakeTVMResponse)
-  await rs.uploadDir('fakeDir', 'fakeprefix')
+  await rs.uploadDir('fakeDir', 'fakeprefix', global.fakeConfig.creds.cna)
   expect(uploadMock).toHaveBeenCalledTimes(3)
 })
 
@@ -160,6 +161,30 @@ test('uploadDir should call a callback once per uploaded file', async () => {
   })
   const cbMock = jest.fn()
   const rs = new RemoteStorage(global.fakeTVMResponse)
-  await rs.uploadDir('fakeDir', 'fakeprefix', cbMock)
+  await rs.uploadDir('fakeDir', 'fakeprefix', global.fakeConfig.cna, cbMock)
   expect(cbMock).toHaveBeenCalledTimes(3)
+})
+
+test('test cachecontrol string for html', async () => {
+  const rs = new RemoteStorage(global.fakeTVMResponse)
+  let response = rs._getCacheControlConfig("text/html", global.fakeConfig.cna)
+  expect(response).toBe("s-maxage=0, max-age=60")
+})
+
+test('test cachecontrol string for JS', async () => {
+  const rs = new RemoteStorage(global.fakeTVMResponse)
+  let response = rs._getCacheControlConfig("application/javascript", global.fakeConfig.cna)
+  expect(response).toBe("s-maxage=0, max-age=604800")
+})
+
+test('test cachecontrol string for CSS', async () => {
+  const rs = new RemoteStorage(global.fakeTVMResponse)
+  let response = rs._getCacheControlConfig("text/css", global.fakeConfig.cna)
+  expect(response).toBe("s-maxage=0, max-age=604800")
+})
+
+test('test cachecontrol string for Image', async () => {
+  const rs = new RemoteStorage(global.fakeTVMResponse)
+  let response = rs._getCacheControlConfig("image/jpeg", global.fakeConfig.cna)
+  expect(response).toBe("s-maxage=0, max-age=604800")
 })

--- a/test/lib/remote-storage.test.js
+++ b/test/lib/remote-storage.test.js
@@ -168,24 +168,30 @@ test('uploadDir should call a callback once per uploaded file', async () => {
 
 test('test cachecontrol string for html', async () => {
   const rs = new RemoteStorage(global.fakeTVMResponse)
-  let response = rs._getCacheControlConfig("text/html", global.fakeConfig.cna)
-  expect(response).toBe("s-maxage=0, max-age=60")
+  const response = rs._getCacheControlConfig('text/html', global.fakeConfig.cna)
+  expect(response).toBe('s-maxage=0, max-age=60')
 })
 
 test('test cachecontrol string for JS', async () => {
   const rs = new RemoteStorage(global.fakeTVMResponse)
-  let response = rs._getCacheControlConfig("application/javascript", global.fakeConfig.cna)
-  expect(response).toBe("s-maxage=0, max-age=604800")
+  const response = rs._getCacheControlConfig('application/javascript', global.fakeConfig.cna)
+  expect(response).toBe('s-maxage=0, max-age=604800')
 })
 
 test('test cachecontrol string for CSS', async () => {
   const rs = new RemoteStorage(global.fakeTVMResponse)
-  let response = rs._getCacheControlConfig("text/css", global.fakeConfig.cna)
-  expect(response).toBe("s-maxage=0, max-age=604800")
+  const response = rs._getCacheControlConfig('text/css', global.fakeConfig.cna)
+  expect(response).toBe('s-maxage=0, max-age=604800')
 })
 
 test('test cachecontrol string for Image', async () => {
   const rs = new RemoteStorage(global.fakeTVMResponse)
-  let response = rs._getCacheControlConfig("image/jpeg", global.fakeConfig.cna)
-  expect(response).toBe("s-maxage=0, max-age=604800")
+  const response = rs._getCacheControlConfig('image/jpeg', global.fakeConfig.cna)
+  expect(response).toBe('s-maxage=0, max-age=604800')
+})
+
+test('test cachecontrol string for default', async () => {
+  const rs = new RemoteStorage(global.fakeTVMResponse)
+  const response = rs._getCacheControlConfig('application/pdf', global.fakeConfig.cna)
+  expect(response).toBe('s-maxage=0')
 })

--- a/test/scripts/deploy.ui.test.js
+++ b/test/scripts/deploy.ui.test.js
@@ -133,17 +133,17 @@ describe('deploy static files with tvm', () => {
 
   test('should fail build if app has no frontend', async () => {
     global.loadFs(vol, 'sample-app')
-    vol.unlinkSync('/web-src/index.html')
+    await global.addFakeFiles(vol, buildDir, ['index.html'])
+
     mockAIOConfig.get.mockReturnValue(global.fakeConfig.tvm)
 
-    const scripts = await AppScripts()
+    scripts._config.app.hasFrontend = false
 
     await expect(scripts.deployUI()).rejects.toEqual(expect.objectContaining({ message: expect.stringContaining('app has no frontend') }))
   })
 
   test('should call onProgress listener', async () => {
     await global.addFakeFiles(vol, buildDir, ['index.html'])
-    const scripts = await AppScripts()
     // spies can be restored
 
     const spy = jest.spyOn(RemoteStorage.prototype, 'uploadDir').mockImplementation((dir, prefix, config, progressCb) => {

--- a/test/scripts/deploy.ui.test.js
+++ b/test/scripts/deploy.ui.test.js
@@ -142,8 +142,9 @@ describe('deploy static files with tvm', () => {
 
   test('should call onProgress listener', async () => {
     await global.addFakeFiles(vol, buildDir, ['index.html'])
+    const scripts = await AppScripts()
     // spies can be restored
-    const spy = jest.spyOn(RemoteStorage.prototype, 'uploadDir').mockImplementation((dir, prefix, progressCb) => {
+    const spy = jest.spyOn(RemoteStorage.prototype, 'uploadDir').mockImplementation((dir, prefix, {}, progressCb) => {
       progressCb('index.html')
     })
     await scripts.deployUI()

--- a/test/scripts/deploy.ui.test.js
+++ b/test/scripts/deploy.ui.test.js
@@ -146,7 +146,7 @@ describe('deploy static files with tvm', () => {
     const scripts = await AppScripts()
     // spies can be restored
 
-    const spy = jest.spyOn(RemoteStorage.prototype, 'uploadDir').mockImplementation((dir, prefix, {}, progressCb) => {
+    const spy = jest.spyOn(RemoteStorage.prototype, 'uploadDir').mockImplementation((dir, prefix, config, progressCb) => {
       progressCb(path.join(buildDir, 'index.html'))
     })
     await scripts.deployUI()


### PR DESCRIPTION
Add S3 metadata while uploading static files.

## Description

Cache control metadata will be added to various types of static files while uploading them to s3.
This will set cache-control header will accessing these files from browser and allow to control their caching.
The header values will have default values.
The value for these headers can be overridden using env variables.


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Fix static files caching issues.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [x ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
