### PR TITLE
support for aio config injection into action inputs manifest

### DIFF
--- a/scripts/deploy.actions.js
+++ b/scripts/deploy.actions.js
@@ -22,6 +22,8 @@ const aioConfig = require('@adobe/aio-lib-core-config')
 
 const aioLogger = require('@adobe/aio-lib-core-logging')('@adobe/aio-app-scripts:deploy-actions', { provider: 'debug' })
 
+const AIO_INPUT_PLACEHOLDER = '$aio.'
+
 // This should eventually be fully covered by `aio runtime deploy`
 class DeployActions extends BaseScript {
   /**
@@ -66,8 +68,8 @@ class DeployActions extends BaseScript {
       // attempt to parse config
       if (action.inputs) {
         Object.entries(action.inputs).forEach(([key, value]) => {
-          if (value.startsWith('$aio.')) {
-            action.inputs[key] = aioConfig.get(value.slice(5)) || ''
+          if (value.startsWith(AIO_INPUT_PLACEHOLDER)) {
+            action.inputs[key] = aioConfig.get(value.slice(AIO_INPUT_PLACEHOLDER.length)) || ''
             aioLogger.debug(`setting input value for ${key} from ${value} to ${JSON.stringify(action.inputs[key])}`)
           }
         })

--- a/test/__fixtures__/sample-app-no-web-input-aioconfig/.aio
+++ b/test/__fixtures__/sample-app-no-web-input-aioconfig/.aio
@@ -1,0 +1,7 @@
+{
+  $ims: {
+    jwt: {
+      key: 'value'
+    }
+  }
+}

--- a/test/__fixtures__/sample-app-no-web-input-aioconfig/.aio
+++ b/test/__fixtures__/sample-app-no-web-input-aioconfig/.aio
@@ -1,7 +1,0 @@
-{
-  $ims: {
-    jwt: {
-      key: 'value'
-    }
-  }
-}

--- a/test/__fixtures__/sample-app-no-web-input-aioconfig/actions/action.js
+++ b/test/__fixtures__/sample-app-no-web-input-aioconfig/actions/action.js
@@ -1,0 +1,15 @@
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+function main (args) {
+  return 'hello'
+}
+exports.main = main

--- a/test/__fixtures__/sample-app-no-web-input-aioconfig/manifest.yml
+++ b/test/__fixtures__/sample-app-no-web-input-aioconfig/manifest.yml
@@ -1,0 +1,12 @@
+packages:
+  __APP_PACKAGE__:
+    license: Apache-2.0
+    actions:
+      action:
+        function: actions/action.js
+        web: yes
+        runtime: 'nodejs:10'
+        inputs:
+          imsConfig: $aio.$ims.jwt
+          empty: $aio.empty
+          normal: hello

--- a/test/__fixtures__/sample-app-no-web-input-aioconfig/package.json
+++ b/test/__fixtures__/sample-app-no-web-input-aioconfig/package.json
@@ -1,0 +1,4 @@
+{
+  "version": "1.0.0",
+  "name": "sample-app"
+}

--- a/test/__fixtures__/sample-app-no-web-input-aioconfig/package.json
+++ b/test/__fixtures__/sample-app-no-web-input-aioconfig/package.json
@@ -1,4 +1,4 @@
 {
   "version": "1.0.0",
-  "name": "sample-app"
+  "name": "sample-app-no-web-input-aioconfig"
 }

--- a/test/scripts/deploy.actions.test.js
+++ b/test/scripts/deploy.actions.test.js
@@ -31,7 +31,7 @@ beforeEach(() => {
   ioruntime.syncProject.mockReset()
 })
 
-const expectedDistManifest = {
+const expectedDistManifestSampleApp = {
   packages: {
     'sample-app-1.0.0': {
       license: 'Apache-2.0',
@@ -107,10 +107,10 @@ test('deploy full manifest', async () => {
   await scripts.deployActions()
 
   expect(ioruntime.processPackage).toHaveBeenCalledTimes(1)
-  expect(ioruntime.processPackage).toHaveBeenCalledWith(expectedDistManifest.packages, {}, {}, {})
+  expect(ioruntime.processPackage).toHaveBeenCalledWith(expectedDistManifestSampleApp.packages, {}, {}, {})
 
   expect(ioruntime.syncProject).toHaveBeenCalledTimes(1)
-  expect(ioruntime.syncProject).toHaveBeenCalledWith('sample-app-1.0.0', r('/manifest.yml'), expectedDistManifest, mockEntities, { fake: 'ow' }, expect.anything(), true)
+  expect(ioruntime.syncProject).toHaveBeenCalledWith('sample-app-1.0.0', r('/manifest.yml'), expectedDistManifestSampleApp, mockEntities, { fake: 'ow' }, expect.anything(), true)
 })
 
 test('use deployConfig.filterEntities to deploy only one action', async () => {
@@ -149,7 +149,7 @@ test('use deployConfig.filterEntities to deploy only one action', async () => {
   expect(ioruntime.processPackage).toHaveBeenCalledWith(expectedDistPackagesFiltered, {}, {}, {})
 
   expect(ioruntime.syncProject).toHaveBeenCalledTimes(1)
-  expect(ioruntime.syncProject).toHaveBeenCalledWith('sample-app-1.0.0', r('/manifest.yml'), expectedDistManifest, mockEntities, { fake: 'ow' }, expect.anything(), false)
+  expect(ioruntime.syncProject).toHaveBeenCalledWith('sample-app-1.0.0', r('/manifest.yml'), expectedDistManifestSampleApp, mockEntities, { fake: 'ow' }, expect.anything(), false)
 })
 
 test('use deployConfig.filterEntities to deploy only one trigger and one action', async () => {
@@ -192,7 +192,7 @@ test('use deployConfig.filterEntities to deploy only one trigger and one action'
   expect(ioruntime.processPackage).toHaveBeenCalledWith(expectedDistPackagesFiltered, {}, {}, {})
 
   expect(ioruntime.syncProject).toHaveBeenCalledTimes(1)
-  expect(ioruntime.syncProject).toHaveBeenCalledWith('sample-app-1.0.0', r('/manifest.yml'), expectedDistManifest, mockEntities, { fake: 'ow' }, expect.anything(), false)
+  expect(ioruntime.syncProject).toHaveBeenCalledWith('sample-app-1.0.0', r('/manifest.yml'), expectedDistManifestSampleApp, mockEntities, { fake: 'ow' }, expect.anything(), false)
 })
 
 test('use deployConfig.filterEntities to deploy only one trigger and one action and one rule', async () => {
@@ -243,7 +243,7 @@ test('use deployConfig.filterEntities to deploy only one trigger and one action 
   expect(ioruntime.processPackage).toHaveBeenCalledWith(expectedDistPackagesFiltered, {}, {}, {})
 
   expect(ioruntime.syncProject).toHaveBeenCalledTimes(1)
-  expect(ioruntime.syncProject).toHaveBeenCalledWith('sample-app-1.0.0', r('/manifest.yml'), expectedDistManifest, mockEntities, { fake: 'ow' }, expect.anything(), false)
+  expect(ioruntime.syncProject).toHaveBeenCalledWith('sample-app-1.0.0', r('/manifest.yml'), expectedDistManifestSampleApp, mockEntities, { fake: 'ow' }, expect.anything(), false)
 })
 
 test('use deployConfig.filterEntities to deploy only one action and one api', async () => {
@@ -294,7 +294,7 @@ test('use deployConfig.filterEntities to deploy only one action and one api', as
   expect(ioruntime.processPackage).toHaveBeenCalledWith(expectedDistPackagesFiltered, {}, {}, {})
 
   expect(ioruntime.syncProject).toHaveBeenCalledTimes(1)
-  expect(ioruntime.syncProject).toHaveBeenCalledWith('sample-app-1.0.0', r('/manifest.yml'), expectedDistManifest, mockEntities, { fake: 'ow' }, expect.anything(), false)
+  expect(ioruntime.syncProject).toHaveBeenCalledWith('sample-app-1.0.0', r('/manifest.yml'), expectedDistManifestSampleApp, mockEntities, { fake: 'ow' }, expect.anything(), false)
 })
 
 test('use deployConfig.filterEntities to deploy only two actions and one sequence', async () => {
@@ -345,7 +345,7 @@ test('use deployConfig.filterEntities to deploy only two actions and one sequenc
   expect(ioruntime.processPackage).toHaveBeenCalledWith(expectedDistPackagesFiltered, {}, {}, {})
 
   expect(ioruntime.syncProject).toHaveBeenCalledTimes(1)
-  expect(ioruntime.syncProject).toHaveBeenCalledWith('sample-app-1.0.0', r('/manifest.yml'), expectedDistManifest, mockEntities, { fake: 'ow' }, expect.anything(), false)
+  expect(ioruntime.syncProject).toHaveBeenCalledWith('sample-app-1.0.0', r('/manifest.yml'), expectedDistManifestSampleApp, mockEntities, { fake: 'ow' }, expect.anything(), false)
 })
 
 test('use deployConfig.filterEntities to deploy only one pkg dependency', async () => {
@@ -382,7 +382,7 @@ test('use deployConfig.filterEntities to deploy only one pkg dependency', async 
   expect(ioruntime.processPackage).toHaveBeenCalledWith(expectedDistPackagesFiltered, {}, {}, {})
 
   expect(ioruntime.syncProject).toHaveBeenCalledTimes(1)
-  expect(ioruntime.syncProject).toHaveBeenCalledWith('sample-app-1.0.0', r('/manifest.yml'), expectedDistManifest, mockEntities, { fake: 'ow' }, expect.anything(), false)
+  expect(ioruntime.syncProject).toHaveBeenCalledWith('sample-app-1.0.0', r('/manifest.yml'), expectedDistManifestSampleApp, mockEntities, { fake: 'ow' }, expect.anything(), false)
 })
 
 test('use deployConfig.filterEntities on non existing pkgEntity should work', async () => {
@@ -463,4 +463,57 @@ test('Deploy actions should pass if there are no build files and filter does not
 
   const scripts = await AppScripts()
   await expect(scripts.deployActions([], { filterEntities: { triggers: ['trigger1'] } })).resolves.toEqual({})
+})
+
+test('Deploy actions with $aio.<key> input field should load aio config into manifest', async () => {
+  global.loadFs(vol, 'sample-app-no-web-input-aioconfig')
+  mockAIOConfig.get.mockReturnValue(global.fakeConfig.tvm)
+  ioruntime.processPackage.mockReturnValue(deepCopy(mockEntities))
+  openwhisk.mockReturnValue({ fake: 'ow' })
+
+  const scripts = await AppScripts()
+  const buildDir = scripts._config.actions.dist
+
+  // fake a previous build
+  await global.addFakeFiles(vol, buildDir, ['action.js'])
+
+  // make sure the $aio. key is define in fixture
+  expect(scripts._config.manifest.package.actions.action.inputs.imsConfig).toEqual('$aio.$ims.jwt')
+
+  mockAIOConfig.get.mockClear()
+  // undefined to test empty: ''
+  mockAIOConfig.get.mockImplementation(k => k === '$ims.jwt' ? { key: 'value', secret: 'secret' } : undefined)
+
+  await scripts.deployActions()
+
+  const expectedDistManifestWithAioConfig = {
+    packages: {
+      'sample-app-1.0.0': {
+        license: 'Apache-2.0',
+        version: '1.0.0',
+        actions: {
+          action: {
+            function: n('dist/actions/action.zip'),
+            runtime: 'nodejs:10',
+            web: 'yes',
+            inputs: {
+              empty: '',
+              normal: 'hello',
+              imsConfig: {
+                key: 'value',
+                secret: 'secret'
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  expect(mockAIOConfig.get).toHaveBeenCalledWith('$ims.jwt')
+
+  expect(ioruntime.processPackage).toHaveBeenCalledTimes(1)
+  expect(ioruntime.processPackage).toHaveBeenCalledWith(expectedDistManifestWithAioConfig.packages, {}, {}, {})
+
+  expect(ioruntime.syncProject).toHaveBeenCalledTimes(1)
+  expect(ioruntime.syncProject).toHaveBeenCalledWith('sample-app-1.0.0', r('/manifest.yml'), expectedDistManifestWithAioConfig, mockEntities, { fake: 'ow' }, expect.anything(), true)
 })

--- a/test/scripts/deploy.actions.test.js
+++ b/test/scripts/deploy.actions.test.js
@@ -488,7 +488,7 @@ test('Deploy actions with $aio.<key> input field should load aio config into man
 
   const expectedDistManifestWithAioConfig = {
     packages: {
-      'sample-app-1.0.0': {
+      'sample-app-no-web-input-aioconfig-1.0.0': {
         license: 'Apache-2.0',
         version: '1.0.0',
         actions: {
@@ -515,5 +515,5 @@ test('Deploy actions with $aio.<key> input field should load aio config into man
   expect(ioruntime.processPackage).toHaveBeenCalledWith(expectedDistManifestWithAioConfig.packages, {}, {}, {})
 
   expect(ioruntime.syncProject).toHaveBeenCalledTimes(1)
-  expect(ioruntime.syncProject).toHaveBeenCalledWith('sample-app-1.0.0', r('/manifest.yml'), expectedDistManifestWithAioConfig, mockEntities, { fake: 'ow' }, expect.anything(), true)
+  expect(ioruntime.syncProject).toHaveBeenCalledWith('sample-app-no-web-input-aioconfig-1.0.0', r('/manifest.yml'), expectedDistManifestWithAioConfig, mockEntities, { fake: 'ow' }, expect.anything(), true)
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Use a placeholder: **$aio.** to indicate that a config should be loaded into the action default parameter.

Example manifest:
```
packages:
  __APP_PACKAGE__:
    license: Apache-2.0
    actions:
      action:
        function: actions/action.js
        web: yes
        runtime: 'nodejs:10'
        inputs:
          imsConfig: $aio.$ims.jwt
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
