### PR TITLE
fix: Linux: no connection to localhost:3233 (closes #87)

### DIFF
--- a/lib/owlocal.js
+++ b/lib/owlocal.js
@@ -4,17 +4,28 @@ const execa = require('execa')
 
 const OW_LOCAL_DOCKER_PORT = 3233
 
+function isWindowsOrMac () {
+  return (
+    process.platform === 'win32' ||
+    process.platform === 'darwin'
+  )
+}
+
 function getDockerNetworkAddress () {
-  const args = ['network', 'inspect', 'bridge']
   try {
-    const result = execa.sync('docker', args)
-    const json = JSON.parse(result.stdout)
-    const ip = json[0].IPAM.Config[0].Gateway
-    return `http://${ip}:${OW_LOCAL_DOCKER_PORT}`
+    // Docker for Windows and macOS do not allow routing to the containers via
+    // IP address, only port forwarding is allowed
+    if (!isWindowsOrMac()) {
+      const args = ['network', 'inspect', 'bridge']
+      const result = execa.sync('docker', args)
+      const json = JSON.parse(result.stdout)
+      return `http://${json[0].IPAM.Config[0].Gateway}:${OW_LOCAL_DOCKER_PORT}`
+    }
   } catch (error) {
     aioLogger.debug('getDockerNetworkAddress', error)
   }
-  return null
+
+  return `http://localhost:${OW_LOCAL_DOCKER_PORT}`
 }
 
 // gets these values if the keys are set in the environment, if not it will use the defaults set
@@ -23,7 +34,7 @@ const {
   OW_JAR_URL = 'https://github.com/adobe/aio-app-scripts/raw/binaries/bin/openwhisk-standalone-0.10.jar',
   // This path will be relative to this module, and not the cwd, so multiple projects can use it.
   OW_JAR_FILE = path.resolve(__dirname, '../bin/openwhisk-standalone.jar'),
-  OW_LOCAL_APIHOST = getDockerNetworkAddress() || `http://localhost:${OW_LOCAL_DOCKER_PORT}`,
+  OW_LOCAL_APIHOST = getDockerNetworkAddress(),
   OW_LOCAL_NAMESPACE = 'guest',
   OW_LOCAL_AUTH = '23bc46b1-71f6-4ed5-8c54-816aa4f8c502:123zO3xZCLrMN6v2BKK1dXYFpXlPkccOFqm12CdAsMgRU4VrNZ9lyGVCGuMDGIwP'
 } = process.env

--- a/lib/owlocal.js
+++ b/lib/owlocal.js
@@ -8,11 +8,9 @@ function getDockerNetworkAddress () {
   const args = ['network', 'inspect', 'bridge']
   try {
     const result = execa.sync('docker', args)
-    if (result.exitCode === 0) {
-      const json = JSON.parse(result.stdout)
-      const ip = json[0].IPAM.Config[0].Gateway
-      return `http://${ip}:${OW_LOCAL_DOCKER_PORT}`
-    }
+    const json = JSON.parse(result.stdout)
+    const ip = json[0].IPAM.Config[0].Gateway
+    return `http://${ip}:${OW_LOCAL_DOCKER_PORT}`
   } catch (error) {
     aioLogger.debug('getDockerNetworkAddress', error)
   }

--- a/lib/owlocal.js
+++ b/lib/owlocal.js
@@ -29,6 +29,8 @@ const {
 } = process.env
 
 module.exports = {
+  getDockerNetworkAddress,
+  OW_LOCAL_DOCKER_PORT,
   OW_JAR_URL,
   OW_JAR_FILE,
   OW_LOCAL_APIHOST,

--- a/lib/owlocal.js
+++ b/lib/owlocal.js
@@ -1,0 +1,39 @@
+const path = require('path')
+const aioLogger = require('@adobe/aio-lib-core-logging')('@adobe/aio-app-scripts:owlocal', { provider: 'debug' })
+const execa = require('execa')
+
+const OW_LOCAL_DOCKER_PORT = 3233
+
+function getDockerNetworkAddress () {
+  const args = ['network', 'inspect', 'bridge']
+  try {
+    const result = execa.sync('docker', args)
+    if (result.exitCode === 0) {
+      const json = JSON.parse(result.stdout)
+      const ip = json[0].IPAM.Config[0].Gateway
+      return `http://${ip}:${OW_LOCAL_DOCKER_PORT}`
+    }
+  } catch (error) {
+    aioLogger.debug('getDockerNetworkAddress', error)
+  }
+  return null
+}
+
+// gets these values if the keys are set in the environment, if not it will use the defaults set
+const {
+  // TODO: this jar should become part of the distro, OR it should be pulled from bintray or similar.
+  OW_JAR_URL = 'https://github.com/adobe/aio-app-scripts/raw/binaries/bin/openwhisk-standalone-0.10.jar',
+  // This path will be relative to this module, and not the cwd, so multiple projects can use it.
+  OW_JAR_FILE = path.resolve(__dirname, '../bin/openwhisk-standalone.jar'),
+  OW_LOCAL_APIHOST = getDockerNetworkAddress() || `http://localhost:${OW_LOCAL_DOCKER_PORT}`,
+  OW_LOCAL_NAMESPACE = 'guest',
+  OW_LOCAL_AUTH = '23bc46b1-71f6-4ed5-8c54-816aa4f8c502:123zO3xZCLrMN6v2BKK1dXYFpXlPkccOFqm12CdAsMgRU4VrNZ9lyGVCGuMDGIwP'
+} = process.env
+
+module.exports = {
+  OW_JAR_URL,
+  OW_JAR_FILE,
+  OW_LOCAL_APIHOST,
+  OW_LOCAL_NAMESPACE,
+  OW_LOCAL_AUTH
+}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -229,6 +229,7 @@ function getCustomConfig (config, key, defaultValue) {
 }
 
 async function downloadOWJar (url, outFile) {
+  aioLogger.debug(`downloadOWJar - url: ${url} outFile: ${outFile}`)
   let response
   try {
     response = await fetch(url)
@@ -252,6 +253,7 @@ async function downloadOWJar (url, outFile) {
 }
 
 async function runOpenWhiskJar (jarFile, apihost, waitInitTime, waitPeriodTime, timeout, /* istanbul ignore next */ execaOptions = {}) {
+  aioLogger.debug(`runOpenWhiskJar - jarFile: ${jarFile} apihost: ${apihost} waitInitTime: ${waitInitTime} waitPeriodTime: ${waitPeriodTime} timeout: ${timeout}`)
   const proc = execa('java', ['-jar', '-Dwhisk.concurrency-limit.max=10', jarFile], execaOptions)
   await waitForOpenWhiskReadiness(apihost, waitInitTime, waitPeriodTime, timeout)
   // must wrap in an object as execa return value is awaitable

--- a/scripts/dev.js
+++ b/scripts/dev.js
@@ -21,22 +21,13 @@ const fs = require('fs-extra')
 const BuildActions = require('./build.actions')
 const DeployActions = require('./deploy.actions')
 const utils = require('../lib/utils')
+const { OW_JAR_FILE, OW_JAR_URL, OW_LOCAL_APIHOST, OW_LOCAL_NAMESPACE, OW_LOCAL_AUTH } = require('../lib/owlocal')
 const execa = require('execa')
 const Bundler = require('parcel-bundler')
 const chokidar = require('chokidar')
 let running = false
 let changed = false
 let watcher
-
-// TODO: this jar should become part of the distro, OR it should be pulled from bintray or similar.
-const OW_JAR_URL = 'https://github.com/adobe/aio-app-scripts/raw/binaries/bin/openwhisk-standalone-0.10.jar'
-
-// This path will be relative to this module, and not the cwd, so multiple projects can use it.
-const OW_JAR_FILE = path.resolve(__dirname, '../bin/openwhisk-standalone.jar')
-
-const OW_LOCAL_APIHOST = 'http://localhost:3233'
-const OW_LOCAL_NAMESPACE = 'guest'
-const OW_LOCAL_AUTH = '23bc46b1-71f6-4ed5-8c54-816aa4f8c502:123zO3xZCLrMN6v2BKK1dXYFpXlPkccOFqm12CdAsMgRU4VrNZ9lyGVCGuMDGIwP'
 
 const owWaitInitTime = 2000
 const owWaitPeriodTime = 500

--- a/test/lib/owlocal.test.js
+++ b/test/lib/owlocal.test.js
@@ -1,0 +1,46 @@
+/*
+Copyright 20290 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+const execa = require('execa')
+const owlocal = require('../../lib/owlocal')
+
+jest.mock('execa')
+
+describe('owlocal - docker network inspect bridge', () => {
+  test('error', () => {
+    execa.sync = jest.fn(() => {
+      return {
+        stdout: '[]'
+      }
+    })
+    expect(owlocal.getDockerNetworkAddress()).toEqual(null)
+  })
+  test('success', () => {
+    const ip = '127.0.0.1'
+    const output = [
+      {
+        IPAM: {
+          Config: [
+            {
+              Gateway: ip
+            }
+          ]
+        }
+      }
+    ]
+    execa.sync = jest.fn(() => {
+      return {
+        stdout: JSON.stringify(output)
+      }
+    })
+    expect(owlocal.getDockerNetworkAddress()).toEqual(`http://${ip}:${owlocal.OW_LOCAL_DOCKER_PORT}`)
+  })
+})


### PR DESCRIPTION
## Description

See #87
Exposes OW_LOCAL_* environment variables for overriding the defaults set in the scripts.

This has minimal impact on the existing `dev` script, the OW_LOCAL_* variables are `require`d from an external file.

## How Has This Been Tested?

npm test
manual test `aio app run --local`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
