### PR TITLE
debugger support for actions with require-adobe-auth annotation

### DIFF
--- a/scripts/dev.js
+++ b/scripts/dev.js
@@ -223,22 +223,24 @@ class ActionServer extends BaseScript {
         if (actionFileStats.isFile()) {
           // why is this condition here?
         }
+        config.runtimeArgs = [
+          `${packageName}/${an}`,
+          actionPath,
+          '-v'
+        ]
         if (actionFileStats.isDirectory()) {
           // take package.json.main or 'index.js'
           const zipMain = utils.getActionEntryFile(path.join(actionPath, 'package.json'))
-          config.runtimeArgs = [
-            `${packageName}/${an}`,
-            path.join(actionPath, zipMain),
-            '-v'
-          ]
-        } else {
-          // we assume its a file at this point
-          // if symlink should have thrown an error during build stage, here we just ignore it
-          config.runtimeArgs = [
-            `${packageName}/${an}`,
-            actionPath,
-            '-v'
-          ]
+          config.runtimeArgs[1] = path.join(actionPath, zipMain)
+        }
+        if (action.annotations && action.annotations['require-adobe-auth']) {
+          // NOTE: The require-adobe-auth annotation is a feature implemented in the
+          // runtime plugin. The current implementation replaces the action by a sequence
+          // and renames the action to __secured_<action>. The annotation will soon be
+          // natively supported in Adobe I/O Runtime, at which point this condition won't
+          // be needed anymore.
+          /* instanbul ignore next */
+          config.runtimeArgs[0] = `${packageName}/__secured_${an}`
         }
         return config
       })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
see https://github.com/adobe/aio-cli-plugin-runtime/pull/135
This is a temporary implementation for the wskdebug to support the action rewrite that occurs in the above PR.
This PR will have to be reverted once the `require-adobe-auth` annotation will be natively supported by Adobe I/O Runtime

<!--- Describe your changes in detail -->
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
