### PR TITLE
Get url support

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ const UndeployActions = require('./scripts/undeploy.actions')
 const RunDev = require('./scripts/dev')
 const AddAuth = require('./scripts/add.auth')
 const Logs = require('./scripts/logs')
+const GetUrl = require('./scripts/get.url')
 
 /**
  * Adobe I/O application scripts
@@ -40,6 +41,7 @@ const Logs = require('./scripts/logs')
  * REMOTE_ACTIONS=true to use remotely deployed actions
  * @property {function(object):Promise<undefined>} addAuth - adds auth capabilities to the application
  * @property {function(object, object):Promise<boolean>} logs - shows action logs
+ * @property {function(object, object):Promise<Object>} getUrls - shows action urls
  */
 
 /**
@@ -94,6 +96,7 @@ module.exports = function (options) {
     runDev: instantiate(RunDev),
     addAuth: instantiate(AddAuth),
     logs: instantiate(Logs),
+    getUrls: instantiate(GetUrl),
     // for unit testing
     _config: appConfig
   }

--- a/scripts/get.url.js
+++ b/scripts/get.url.js
@@ -1,0 +1,41 @@
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const Openwhisk = require('openwhisk')
+const BaseScript = require('../lib/abstract-script')
+const utils = require('../lib/utils')
+
+class GetUrl extends BaseScript {
+
+  async run (options = {}) {
+    const taskName = 'GetUrl'
+    this.emit('start', taskName)
+    let urls = {}
+    if(options.action) {
+      const action = this.config.manifest.package.actions[options.action]
+      if(!action) {
+        throw new Error(`No action with name ${options.action} found`)
+      }
+      this.config.manifest.package.actions = {}
+      this.config.manifest.package.actions[options.action] = action
+    }
+    const actionUrls = await utils.getActionUrls(this.config, true)
+    urls.runtime = actionUrls
+    if(options.cdn) {
+      const cdnUrls = await utils.getActionUrls(this.config, false)
+      urls.cdn = cdnUrls
+    }
+    this.emit('end', taskName)
+    return urls
+  }
+}
+module.exports = GetUrl

--- a/scripts/get.url.js
+++ b/scripts/get.url.js
@@ -12,24 +12,26 @@ governing permissions and limitations under the License.
 
 const BaseScript = require('../lib/abstract-script')
 const utils = require('../lib/utils')
+const cloneDeep = require('lodash.clonedeep')
 
 class GetUrl extends BaseScript {
   async run (options = {}) {
     const taskName = 'GetUrl'
     this.emit('start', taskName)
     const urls = {}
+    const configCopy = cloneDeep(this.config)
     if (options.action) {
       const action = this.config.manifest.package.actions[options.action]
       if (!action) {
         throw new Error(`No action with name ${options.action} found`)
       }
-      this.config.manifest.package.actions = {}
-      this.config.manifest.package.actions[options.action] = action
+      configCopy.manifest.package.actions = {}
+      configCopy.manifest.package.actions[options.action] = action
     }
-    const actionUrls = await utils.getActionUrls(this.config, true)
+    const actionUrls = await utils.getActionUrls(configCopy, true)
     urls.runtime = actionUrls
     if (options.cdn) {
-      const cdnUrls = await utils.getActionUrls(this.config, false)
+      const cdnUrls = await utils.getActionUrls(configCopy, false)
       urls.cdn = cdnUrls
     }
     this.emit('end', taskName)

--- a/scripts/get.url.js
+++ b/scripts/get.url.js
@@ -34,7 +34,7 @@ class GetUrl extends BaseScript {
       const cdnUrls = await utils.getActionUrls(configCopy, false)
       urls.cdn = cdnUrls
     }
-    this.emit('end', taskName)
+    this.emit('end', taskName, JSON.stringify(urls))
     return urls
   }
 }

--- a/scripts/get.url.js
+++ b/scripts/get.url.js
@@ -10,19 +10,17 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const Openwhisk = require('openwhisk')
 const BaseScript = require('../lib/abstract-script')
 const utils = require('../lib/utils')
 
 class GetUrl extends BaseScript {
-
   async run (options = {}) {
     const taskName = 'GetUrl'
     this.emit('start', taskName)
-    let urls = {}
-    if(options.action) {
+    const urls = {}
+    if (options.action) {
       const action = this.config.manifest.package.actions[options.action]
-      if(!action) {
+      if (!action) {
         throw new Error(`No action with name ${options.action} found`)
       }
       this.config.manifest.package.actions = {}
@@ -30,7 +28,7 @@ class GetUrl extends BaseScript {
     }
     const actionUrls = await utils.getActionUrls(this.config, true)
     urls.runtime = actionUrls
-    if(options.cdn) {
+    if (options.cdn) {
       const cdnUrls = await utils.getActionUrls(this.config, false)
       urls.cdn = cdnUrls
     }

--- a/test/scripts/get.url.test.js
+++ b/test/scripts/get.url.test.js
@@ -1,0 +1,81 @@
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+const { vol } = global.mockFs()
+const AppScripts = require('../..')
+const mockAIOConfig = require('@adobe/aio-lib-core-config')
+const retUrls = {
+  action: 'https://fake_ns.adobeioruntime.net/api/v1/web/sample-app-1.0.0/action',
+  'action-zip': 'https://fake_ns.adobeioruntime.net/api/v1/web/sample-app-1.0.0/action-zip',
+  cdnAction: 'https://fake_ns.adobeio-static.net/api/v1/web/sample-app-1.0.0/action',
+  'cdnAction-zip': 'https://fake_ns.adobeio-static.net/api/v1/web/sample-app-1.0.0/action-zip'
+}
+
+beforeEach(() => {
+  global.cleanFs(vol)
+})
+
+test('get all action URLs', async () => {
+  global.loadFs(vol, 'sample-app')
+
+  mockAIOConfig.get.mockReturnValue(global.fakeConfig.tvm)
+
+  const scripts = await AppScripts()
+  const urls = await scripts.getUrls()
+  expect(urls.runtime).toEqual(expect.objectContaining({ action: retUrls.action }))
+  expect(urls.runtime).toEqual(expect.objectContaining({ 'action-zip': retUrls['action-zip'] }))
+})
+
+test('get all action URLs with cdn flag', async () => {
+  global.loadFs(vol, 'sample-app')
+
+  mockAIOConfig.get.mockReturnValue(global.fakeConfig.tvm)
+
+  const scripts = await AppScripts()
+  const urls = await scripts.getUrls({ cdn: true })
+  expect(urls.runtime).toEqual(expect.objectContaining({ action: retUrls.action }))
+  expect(urls.runtime).toEqual(expect.objectContaining({ 'action-zip': retUrls['action-zip'] }))
+  expect(urls.cdn).toEqual(expect.objectContaining({ action: retUrls.cdnAction }))
+  expect(urls.cdn).toEqual(expect.objectContaining({ 'action-zip': retUrls['cdnAction-zip'] }))
+})
+
+test('get single action URL with cdn flag', async () => {
+  global.loadFs(vol, 'sample-app')
+
+  mockAIOConfig.get.mockReturnValue(global.fakeConfig.tvm)
+
+  const scripts = await AppScripts()
+  const urls = await scripts.getUrls({ action: 'action', cdn: true })
+  expect(urls.runtime['action-zip']).toBeUndefined()
+  expect(urls.runtime).toEqual(expect.objectContaining({ action: retUrls.action }))
+  expect(urls.cdn['action-zip']).toBeUndefined()
+  expect(urls.cdn).toEqual(expect.objectContaining({ action: retUrls.cdnAction }))
+})
+
+test('get single action URL', async () => {
+  global.loadFs(vol, 'sample-app')
+
+  mockAIOConfig.get.mockReturnValue(global.fakeConfig.tvm)
+
+  const scripts = await AppScripts()
+  const urls = await scripts.getUrls({ action: 'action' })
+  expect(urls.runtime['action-zip']).toBeUndefined()
+  expect(urls.runtime).toEqual(expect.objectContaining({ action: retUrls.action }))
+})
+
+test('Throw error for non existing action', async () => {
+  global.loadFs(vol, 'sample-app')
+
+  mockAIOConfig.get.mockReturnValue(global.fakeConfig.tvm)
+
+  const scripts = await AppScripts()
+  await expect(scripts.getUrls({ action: 'invalid' })).rejects.toThrow('No action with name invalid found')
+})


### PR DESCRIPTION
Added script to return Action URLs
1) For all actions in manifest
2) Specific action using 'action' option
3) CDN URLs for actions using 'cdn' flag

## Description
Return action URLs for
1) For all actions in manifest
2) Specific action using 'action' option
3) CDN URLs for actions using 'cdn' flag

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Support get-url command in aio app plugin

## How Has This Been Tested?

unit tests, and via CLI

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [ x] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
