### PR TITLE
simplify static asset deployment path

### DIFF
--- a/lib/config-loader.js
+++ b/lib/config-loader.js
@@ -147,7 +147,7 @@ module.exports = () => {
   config.ow.apihost = config.ow.apihost || defaultOwApiHost
   config.ow.apiversion = config.ow.apiversion || 'v1'
   config.ow.package = `${config.app.name}-${config.app.version}`
-  config.s3.folder = utils.urlJoin(config.ow.namespace, config.ow.package)
+  config.s3.folder = config.ow.namespace // this becomes the root only /
   config.s3.tvmUrl = userConfig.cna.tvmurl || defaultTvmUrl
   // only provide a hostname if it was given or if the app uses the tvm
   config.app.hostname = userConfig.cna.hostname || defaultAioHostname

--- a/lib/owlocal.js
+++ b/lib/owlocal.js
@@ -22,7 +22,7 @@ function getDockerNetworkAddress () {
       return `http://${json[0].IPAM.Config[0].Gateway}:${OW_LOCAL_DOCKER_PORT}`
     }
   } catch (error) {
-    aioLogger.debug('getDockerNetworkAddress', error)
+    aioLogger.debug(`getDockerNetworkAddress ${error}`)
   }
 
   return `http://localhost:${OW_LOCAL_DOCKER_PORT}`

--- a/lib/remote-storage.js
+++ b/lib/remote-storage.js
@@ -81,7 +81,9 @@ module.exports = class RemoteStorage {
    * @param  {Object} appConfig - application config
    */
   async uploadFile (file, prefix, appConfig) {
-    if (typeof prefix !== 'string') throw new Error('prefix must be a valid string')
+    if (typeof prefix !== 'string') {
+      throw new Error('prefix must be a valid string')
+    }
     const content = await fs.readFile(file)
     const mimeType = mime.lookup(path.extname(file))
     const cacheControlString = this._getCacheControlConfig(mimeType, appConfig)
@@ -104,7 +106,9 @@ module.exports = class RemoteStorage {
    * @param  {function} [postFileUploadCallback] - called for each uploaded file
    */
   async uploadDir (dir, prefix, appConfig, postFileUploadCallback) {
-    if (typeof prefix !== 'string') throw new Error('prefix must be a valid string')
+    if (typeof prefix !== 'string') {
+      throw new Error('prefix must be a valid string')
+    }
 
     // walk the whole directory recursively using klaw.
     const files = []
@@ -124,7 +128,9 @@ module.exports = class RemoteStorage {
       const newPrefix = utils.urlJoin(prefix, prefixDirectory)
       const s3Res = await this.uploadFile(f, newPrefix, appConfig)
 
-      if (postFileUploadCallback) postFileUploadCallback(f)
+      if (postFileUploadCallback) {
+        postFileUploadCallback(f)
+      }
       return s3Res
     }))
   }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -360,12 +360,6 @@ function getActionUrls (config, /* istanbul ignore next */ isRemoteDev = false, 
   }, {})
 }
 
-function getUIUrl (config, bucket) {
-  return `https://${config.ow.namespace}.${config.app.hostname}/${config.ow.package}/index.html`
-  // in future if no hostname + custom s3 creds set we might want to return s3 url?
-  // return `https://s3.amazonaws.com/${bucket}/${config.ow.namespace}/${config.ow.package}/index.html`
-}
-
 function removeProtocolFromURL (url) {
   return url.replace(/(^\w+:|^)\/\//, '')
 }
@@ -388,7 +382,6 @@ module.exports = {
   checkOpenWhiskCredentials,
   checkFile,
   getActionUrls,
-  getUIUrl,
   removeProtocolFromURL,
   getActionEntryFile
 }

--- a/scripts/deploy.ui.js
+++ b/scripts/deploy.ui.js
@@ -14,7 +14,6 @@ governing permissions and limitations under the License.
 const BaseScript = require('../lib/abstract-script')
 const TvmClient = require('@adobe/aio-lib-core-tvm')
 const RemoteStorage = require('../lib/remote-storage')
-const utils = require('../lib/utils')
 
 const fs = require('fs-extra')
 const path = require('path')
@@ -46,15 +45,14 @@ class DeployUI extends BaseScript {
         })).getAwsS3Credentials()
 
     const remoteStorage = new RemoteStorage(creds)
-
     if (await remoteStorage.folderExists(this.config.s3.folder)) {
-      this.emit('warning', `an already existing deployment for version ${this.config.app.version} will be overwritten`)
+      this.emit('warning', 'an existing deployment will be overwritten')
       await remoteStorage.emptyFolder(this.config.s3.folder)
     }
 
     await remoteStorage.uploadDir(dist, this.config.s3.folder, this.config.app, f => this.emit('progress', path.relative(dist, f)))
 
-    const url = utils.getUIUrl(this.config, creds.params.Bucket)
+    const url = `https://${this.config.ow.namespace}.${this.config.app.hostname}/index.html`
     this.emit('end', taskName, url)
     return url
   }

--- a/test/lib/utils.test.js
+++ b/test/lib/utils.test.js
@@ -53,8 +53,6 @@ describe('lib/utils', () => {
     expect(typeof utils.saveAndReplaceDotEnvCredentials).toBe('function')
     expect(utils.getActionUrls).toBeDefined()
     expect(typeof utils.getActionUrls).toBe('function')
-    expect(utils.getUIUrl).toBeDefined()
-    expect(typeof utils.getUIUrl).toBe('function')
     expect(utils.getActionEntryFile).toBeDefined()
     expect(typeof utils.getActionEntryFile).toBe('function')
   })

--- a/test/scripts/deploy.ui.test.js
+++ b/test/scripts/deploy.ui.test.js
@@ -113,7 +113,7 @@ describe('deploy static files with tvm', () => {
     // spies can be restored
     await global.addFakeFiles(vol, buildDir, ['index.html'])
     const url = await scripts.deployUI()
-    expect(url).toBe('https://fake_ns.adobeio-static.net/sample-app-1.0.0/index.html')
+    expect(url).toBe('https://fake_ns.adobeio-static.net/index.html')
   })
 
   // below = those are common with s3 credential mode
@@ -123,7 +123,7 @@ describe('deploy static files with tvm', () => {
     const spy = jest.spyOn(RemoteStorage.prototype, 'folderExists').mockReturnValue(true)
     await global.addFakeFiles(vol, buildDir, ['index.html'])
     await scripts.deployUI()
-    expect(mockOnWarning).toHaveBeenCalledWith('an already existing deployment for version 1.0.0 will be overwritten')
+    expect(mockOnWarning).toHaveBeenCalled()
     spy.mockRestore()
   })
 

--- a/test/scripts/undeploy.ui.test.js
+++ b/test/scripts/undeploy.ui.test.js
@@ -69,7 +69,7 @@ describe('Undeploy static files with tvm', () => {
   test('Should throw an error if there are no deployment', async () => {
     // spies can be restored
     const spy = jest.spyOn(RemoteStorage.prototype, 'folderExists').mockReturnValue(false)
-    await expect(scripts.undeployUI()).rejects.toEqual(expect.objectContaining({ message: 'cannot undeploy static files, there is no deployment for fake_ns/sample-app-1.0.0' }))
+    await expect(scripts.undeployUI()).rejects.toEqual(expect.objectContaining({ message: 'cannot undeploy static files, there is no deployment for fake_ns' }))
     spy.mockRestore()
   })
 })


### PR DESCRIPTION

## Description
the url for any Project Firefly app becomes simply:
https://<namespace>.adobeio-static.net/
- this allows for predictable urls, and we need less config
- this should resolve any issues apps have when served from a subdir, and not using <base>

<!--- Describe your changes in detail -->

## Related Issue
https://github.com/adobe/aio-cli-plugin-app/issues/188
[ACNA-740]

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
