### PR TITLE
rename to aio-lib-web

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,42 +10,16 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 -->
 
-[![Version](https://img.shields.io/npm/v/@adobe/aio-app-scripts.svg)](https://npmjs.org/package/@adobe/aio-app-scripts)
-[![Downloads/week](https://img.shields.io/npm/dw/@adobe/aio-app-scripts.svg)](https://npmjs.org/package/@adobe/aio-app-scripts)
-[![Build Status](https://travis-ci.com/adobe/aio-app-scripts.svg?branch=master)](https://travis-ci.com/adobe/aio-app-scripts)
+[![Version](https://img.shields.io/npm/v/@adobe/aio-lib-web.svg)](https://npmjs.org/package/@adobe/aio-lib-web)
+[![Downloads/week](https://img.shields.io/npm/dw/@adobe/aio-lib-web.svg)](https://npmjs.org/package/@adobe/aio-lib-web)
+[![Build Status](https://travis-ci.com/adobe/aio-lib-web.svg?branch=master)](https://travis-ci.com/adobe/aio-lib-web)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) 
-[![Codecov Coverage](https://img.shields.io/codecov/c/github/adobe/aio-app-scripts/master.svg?style=flat-square)](https://codecov.io/gh/adobe/aio-app-scripts/)
+[![Codecov Coverage](https://img.shields.io/codecov/c/github/adobe/aio-lib-web/master.svg?style=flat-square)](https://codecov.io/gh/adobe/aio-lib-web/)
 
-**IMPORTANT NOTICE: `adobe/aio-app-scripts` will be removed entirely soon, the logic is being moved to [adobe/aio-cli-plugin-app](https://github.com/adobe/aio-cli-plugin-app) and [adobe/aio-lib-runtime](https://github.com/adobe/aio-lib-runtime).**
 
-**Please make sure to not depend on `@adobe/aio-app-scripts` anymore.**
+# aio-lib-web
 
-**No contributions to this repository will be accepted.**
-
-# AIO App Scripts
-
-Utility tooling scripts to build, deploy and run Adobe I/O Apps
-
-## Include as a library in your nodejs project
-
-```bash
-npm i --save @adobe/aio-app-scripts
-```
-
-```js
-const appScripts = require('@adobe/aio-app-scripts')({
-  listeners: {
-    onStart: taskName => console.error(`${taskName} ...`),
-    onEnd: (taskName, res) => { console.error(`${taskName} done!`); if (res) console.log(res) },
-    onWarning: warning => console.error(warning),
-    onProgress: item => console.error(`  > ${item}`)
-  }
-})
-
-appScripts.buildUI()
-  .then(appScripts.deployUI)
-  .catch(e => { console.error(e); process.exit(1) })
-```
+Utility tooling scripts to build, deploy and run Project Firefly app static sites to CDN
 
 ## Explore
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ governing permissions and limitations under the License.
 
 # aio-lib-web
 
-Utility tooling scripts to build, deploy and run Project Firefly app static sites to CDN
+Utility tooling library to build and deploy Adobe I/O Project Firefly app static sites to CDN
 
 ## Explore
 

--- a/doc/api.md
+++ b/doc/api.md
@@ -1,40 +1,17 @@
-<a name="module_adobe/aio-app-scripts"></a>
+<a name="module_adobe/aio-lib-web"></a>
 
-## adobe/aio-app-scripts
-Adobe I/O application scripts
+## adobe/aio-lib-web
+Adobe I/O app lib web, build / deploy webapps to cdn
 
+<a name="module_adobe/aio-lib-web..AppLibWeb"></a>
 
-* [adobe/aio-app-scripts](#module_adobe/aio-app-scripts)
-    * [module.exports([options])](#exp_module_adobe/aio-app-scripts--module.exports) ⇒ <code>AppScripts</code> ⏏
-        * [~AppScripts](#module_adobe/aio-app-scripts--module.exports..AppScripts) : <code>object</code>
-
-<a name="exp_module_adobe/aio-app-scripts--module.exports"></a>
-
-### module.exports([options]) ⇒ <code>AppScripts</code> ⏏
-Returns application scripts functions
-
-**Kind**: Exported function  
-**Returns**: <code>AppScripts</code> - With all script functions  
-
-| Param | Type |
-| --- | --- |
-| [options] | <code>object</code> | 
-| [options.listeners] | <code>object</code> | 
-| [options.listeners.onStart] | <code>function</code> | 
-| [options.listeners.onEnd] | <code>function</code> | 
-| [options.listeners.onProgress] | <code>function</code> | 
-| [options.listeners.onResource] | <code>function</code> | 
-| [options.listeners.onWarning] | <code>function</code> | 
-
-<a name="module_adobe/aio-app-scripts--module.exports..AppScripts"></a>
-
-#### module.exports~AppScripts : <code>object</code>
-**Kind**: inner typedef of [<code>module.exports</code>](#exp_module_adobe/aio-app-scripts--module.exports)  
+### adobe/aio-lib-web~AppLibWeb : <code>object</code>
+**Kind**: inner typedef of [<code>adobe/aio-lib-web</code>](#module_adobe/aio-lib-web)  
 **Properties**
 
 | Name | Type | Description |
 | --- | --- | --- |
-| buildUI | <code>function</code> | bundles the application's static files |
-| deployUI | <code>function</code> | deploys the static files to a CDN, returns the URL |
-| undeployUI | <code>function</code> | removes the deployed static files |
+| buildWeb | <code>function</code> | bundles the application's static files |
+| deployWeb | <code>function</code> | deploys the static files to a CDN, returns the URL |
+| undeployWeb | <code>function</code> | removes the deployed static files |
 

--- a/index.js
+++ b/index.js
@@ -15,12 +15,12 @@ const deployWeb = require('./src/deploy-web')
 const undeployWeb = require('./src/undeploy-web')
 
 /**
- * Adobe I/O application scripts
- * @module adobe/aio-app-scripts
+ * Adobe I/O app lib web, build / deploy webapps to cdn
+ * @module adobe/aio-lib-web
  */
 
 /**
- * @typedef AppScripts
+ * @typedef AppLibWeb
  * @type {object}
  * @property {function(object):Promise<undefined>} buildWeb - bundles the application's static files
  * @property {function(object):Promise<string>} deployWeb - deploys the static files to a CDN, returns the URL

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@adobe/aio-app-scripts",
+  "name": "@adobe/aio-lib-web",
   "version": "2.5.1",
-  "description": "Utility tooling scripts to build, deploy and run an Adobe I/O App",
+  "description": "Utility tooling library to build, deploy and run an Adobe I/O App static website to cdn",
   "main": "index.js",
   "directories": {
     "lib": "lib",
@@ -12,8 +12,8 @@
   "engines": {
     "node": ">=10.0.0"
   },
-  "repository": "adobe/aio-app-scripts",
-  "homepage": "https://github.com/adobe/aio-app-scripts",
+  "repository": "adobe/aio-lib-web",
+  "homepage": "https://github.com/adobe/aio-lib-web",
   "keywords": [
     "openwhisk",
     "reactjs",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@adobe/aio-lib-web",
   "version": "2.5.1",
-  "description": "Utility tooling library to build, deploy and run an Adobe I/O App static website to cdn",
+  "description": "Utility tooling library to build and deploy Adobe I/O Project Firefly app static sites to CDN",
   "main": "index.js",
   "directories": {
     "lib": "lib",

--- a/test/__mocks__/parcel-bundler.js
+++ b/test/__mocks__/parcel-bundler.js
@@ -10,9 +10,6 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-// need to manually mock because parcel seems to fs read
-// /Users/mraho/work/aio-app-scripts/node_modules/grapheme-breaker/src/classes.trie which conflicts with fs mocking
-
 const mockBundle = jest.fn()
 const mockMiddleware = jest.fn()
 const mockConstructor = jest.fn()


### PR DESCRIPTION
This changes all occurrences of aio-app-script to aio-lib-web
Next step will be to rename the repo itself, and update all links to it.

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
